### PR TITLE
Update makefile to work with current/recent macos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,8 +15,10 @@ CPPFLAGS += -m64
 endif
 endif
 
+KERNELDIR := $(shell xcrun --sdk macosx --show-sdk-path)/System/Library/Frameworks/Kernel.framework/Headers
+
 $(BIN): $(DIR) $(NAME).c Makefile
-	$(CC) $(CFLAGS) $(CPPFLAGS) $(MARCH) -Xlinker -kext -static $(NAME).c -o $@ -fno-builtin -nostdlib -lkmod -r -Wall
+	$(CC) $(CFLAGS) $(CPPFLAGS) $(MARCH) -Xlinker -kext --include-directory=$(KERNELDIR) -static $(NAME).c -o $@ -fno-builtin -nostdlib -lkmod -r -Wall
 
 $(DIR):; mkdir -p $(DIR)
 


### PR DESCRIPTION
Need to include the Headers directory for the link to libkern/crc.h to work.